### PR TITLE
Add pytest and CI workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,25 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run tests
+        run: |
+          pytest -v

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from data_utils import add_technical_indicators
+
+def test_add_technical_indicators():
+    data = {
+        'open': list(range(40)),
+        'high': [x + 1 for x in range(40)],
+        'low': [x - 1 for x in range(40)],
+        'close': list(range(40)),
+        'volume': [100] * 40,
+    }
+    df = pd.DataFrame(data)
+    result = add_technical_indicators(df)
+    for col in ['sma_20', 'rsi', 'macd', 'atr']:
+        assert col in result.columns
+        assert not result[col].isna().any()


### PR DESCRIPTION
## Summary
- add a basic pytest test for `add_technical_indicators`
- run the tests via GitHub Actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6879c139c85c8330befb36e1c01c52c9